### PR TITLE
Synchronized clock

### DIFF
--- a/examples/clock10.html
+++ b/examples/clock10.html
@@ -1,0 +1,24 @@
+<html>
+<head>
+  <title>jclock - default 24-hour clock (localtime)</title>
+
+  <script type="text/javascript" src="jquery-1.3.1.min.js"></script>
+  <script type="text/javascript" src="jquery.jclock.js"></script>
+
+  <script type="text/javascript">
+    $(function($) {
+      $('.jclock').jclock({
+		  timeout: 60000,
+	      format: '%H:%M',
+	  });
+    });
+  </script>
+
+</head>
+
+<body>
+
+<div class="jclock"></div>
+
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -15,6 +15,7 @@
 <li><a href="clock7.html">multiple clocks using different time zone offsets</a></li>
 <li><a href="clock8.html">styled clocks (first clock uses jquery.corner.js)</a></li>
 <li><a href="clock9.html">clock using seedTime</a></li>
+<li><a href="clock10.html">clock with only minutes</a></li>
 </ul>
 </body>
 <html>

--- a/examples/jquery.jclock.js
+++ b/examples/jquery.jclock.js
@@ -106,12 +106,23 @@
     el.running = false;
   }
  
+  /* if the frequency is "once every minute" then we have to make sure this happens
+   * when the minute changes. */  
+  // got this idea from digiclock http://www.radoslavdimov.com/jquery-plugins/jquery-plugin-digiclock/
+  function getDelay(timeout) {
+	  if (timeout == 60000) {
+		  var now = new Date();
+		  timeout = 60000 - now.getSeconds() * 1000; // number of seconds before the next minute
+	  }
+	  return timeout;
+  }
+  
   $.fn.jclock.displayTime = function(el) {
     var time = $.fn.jclock.currentTime(el);
     var formatted_time = $.fn.jclock.formatTime(time, el);
     el.attr('currentTime', time.getTime())
     el.html(formatted_time);
-    el.timerID = setTimeout(function(){$.fn.jclock.displayTime(el)},el.timeout);
+    el.timerID = setTimeout(function(){$.fn.jclock.displayTime(el)}, getDelay(el.timeout));
   }
 
   $.fn.jclock.currentTime = function(el) {

--- a/jquery.jclock.js
+++ b/jquery.jclock.js
@@ -106,12 +106,23 @@
     el.running = false;
   }
  
+  /* if the frequency is "once every minute" then we have to make sure this happens
+   * when the minute changes. */  
+  // got this idea from digiclock http://www.radoslavdimov.com/jquery-plugins/jquery-plugin-digiclock/
+  function getDelay(timeout) {
+	  if (timeout == 60000) {
+		  var now = new Date();
+		  timeout = 60000 - now.getSeconds() * 1000; // number of seconds before the next minute
+	  }
+	  return timeout;
+  }
+  
   $.fn.jclock.displayTime = function(el) {
     var time = $.fn.jclock.currentTime(el);
     var formatted_time = $.fn.jclock.formatTime(time, el);
     el.attr('currentTime', time.getTime())
     el.html(formatted_time);
-    el.timerID = setTimeout(function(){$.fn.jclock.displayTime(el)},el.timeout);
+    el.timerID = setTimeout(function(){$.fn.jclock.displayTime(el)}, getDelay(el.timeout));
   }
 
   $.fn.jclock.currentTime = function(el) {


### PR DESCRIPTION
with the current implementation, there is a problem when the timeout is set to 60000 (ie 1 minute) instead of the default 1000. In this case, the change (the repaint) is set to 1 minute after the startClock call, which means it will most probably not in the same time as the minute change.

This pull request tries to fix this: if the timeout is 1 minute, then we compute the timeout to be the number of seconds to the next minute.

An example file (index10.html) has been added to demonstrate this.
