### PR TITLE
Dynamically update a clock

### DIFF
--- a/examples/clock-set-time.html
+++ b/examples/clock-set-time.html
@@ -9,7 +9,8 @@
   <script type="text/javascript">
     $(function($) {
       var options = {
-        format: '%I:%M:%S' // 12-hour
+        format: '%I:%M:%S', // 12-hour
+        timeout: 500
       }
       $('.jclock').jclock(options);
       $('#set-button').click(function(){
@@ -34,7 +35,7 @@
         <label class="time-label">Minutes:</label> <br />
         <input type="text" id="mins" value="59" size="4" /> <br />
         <label class="time-label">Seconds:</label> <br />
-        <input type="text" id="secs" value="59" size="4" /> <br />
+        <input type="text" id="secs" value="50" size="4" /> <br />
         <br />
         <button id="set-button">Set Time</button>
 </div>

--- a/examples/clock-set-time.html
+++ b/examples/clock-set-time.html
@@ -1,0 +1,43 @@
+<html>
+<head>
+  <title>jclock - set time</title>
+
+  <script type="text/javascript" src="jquery-1.3.1.min.js"></script>
+  <script type="text/javascript" src="../jquery.jclock.js"></script>
+  <style type="text/css">
+  </style>
+  <script type="text/javascript">
+    $(function($) {
+      var options = {
+        format: '%I:%M:%S' // 12-hour
+      }
+      $('.jclock').jclock(options);
+      $('#set-button').click(function(){
+          var t = (new Date());
+          t.setHours($('#hours').val());
+          t.setMinutes($('#mins').val());
+          t.setSeconds($('#secs').val());
+          $('.jclock').jclock('setSeedTime', t.getTime());
+      });
+    });
+  </script>
+
+</head>
+
+<body>
+
+<div class="jclock"></div>
+<br />
+<div>
+        <label class="time-label">Hours:</label> <br />
+        <input type="text" id="hours" value="12" size="4" /> <br />
+        <label class="time-label">Minutes:</label> <br />
+        <input type="text" id="mins" value="59" size="4" /> <br />
+        <label class="time-label">Seconds:</label> <br />
+        <input type="text" id="secs" value="59" size="4" /> <br />
+        <br />
+        <button id="set-button">Set Time</button>
+</div>
+
+</body>
+</html>

--- a/examples/clock-start-stop.html
+++ b/examples/clock-start-stop.html
@@ -13,9 +13,13 @@
       $('.jclock').jclock(options);
       $('#start-button').click(function(){
           $('.jclock').jclock('startClock');
+          $('#stop-button').removeAttr('disabled');
+          $('#start-button').attr('disabled', 'disabled');
       });
       $('#stop-button').click(function(){
           $('.jclock').jclock('stopClock');
+          $('#start-button').removeAttr('disabled');
+          $('#stop-button').attr('disabled', 'disabled');
       });
     });
   </script>
@@ -25,7 +29,7 @@
 <body>
 
 <div class="jclock"></div>
-<div><button id="start-button">Start</button></div>
+<div><button id="start-button" disabled="disabled">Start</button></div>
 <div><button id="stop-button">Stop</button></div>
 
 </body>

--- a/examples/clock-start-stop.html
+++ b/examples/clock-start-stop.html
@@ -1,0 +1,32 @@
+<html>
+<head>
+  <title>jclock - start and stop</title>
+
+  <script type="text/javascript" src="jquery-1.3.1.min.js"></script>
+  <script type="text/javascript" src="../jquery.jclock.js"></script>
+
+  <script type="text/javascript">
+    $(function($) {
+      var options = {
+        format: '%I:%M:%S', // 12-hour
+      }
+      $('.jclock').jclock(options);
+      $('#start-button').click(function(){
+          $('.jclock').jclock('startClock');
+      });
+      $('#stop-button').click(function(){
+          $('.jclock').jclock('stopClock');
+      });
+    });
+  </script>
+
+</head>
+
+<body>
+
+<div class="jclock"></div>
+<div><button id="start-button">Start</button></div>
+<div><button id="stop-button">Stop</button></div>
+
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -16,6 +16,8 @@
 <li><a href="clock8.html">styled clocks (first clock uses jquery.corner.js)</a></li>
 <li><a href="clock9.html">clock using seedTime</a></li>
 <li><a href="clock10.html">clock with only minutes</a></li>
+<li><a href="clock-start-stop.html">clock with start and stop buttons</a></li>
+<li><a href="clock-set-time.html">change time on the clock</a></li>
 </ul>
 </body>
 <html>

--- a/jquery.jclock.js
+++ b/jquery.jclock.js
@@ -114,6 +114,17 @@
     });
    },   
    /**
+    * Start the clock's timer if it has been stopped
+    */
+   startClock: function( ) {  
+    return this.each(function(){
+        var $this = $(this).data('clock');
+        if ($this != null) {      
+            $.fn.jclock.startClock($this);
+        }
+    });
+   },
+   /**
     * Stop the clock's timer, for example in 
     * preparation to destroy the clock instance.
     */
@@ -279,3 +290,4 @@
   };
  
 })(jQuery);
+

--- a/jquery.jclock.js
+++ b/jquery.jclock.js
@@ -1,16 +1,19 @@
-/*
-* jQuery jclock - Clock plugin - v 2.3.2
-* http://plugins.jquery.com/project/jclock
-*
-* Copyright (c) 2007-2011 Doug Sparling <http://www.dougsparling.com>
-* Licensed under the MIT License:
-* http://www.opensource.org/licenses/mit-license.php
-*/
+/**
+ * jQuery jclock - Clock plugin - v 2.3.2
+ * http://plugins.jquery.com/project/jclock
+ *
+ * Copyright (c) 2007-2011 Doug Sparling <http://www.dougsparling.com>
+ * Licensed under the MIT License:
+ * http://www.opensource.org/licenses/mit-license.php
+ */
 (function($) {
- 
-  $.fn.jclock = function(options) {
-    var version = '2.3.2';
- 
+  var version = '2.3.2',
+      methods = {
+   /**
+    * Initializes the clock
+    */
+   init : function( options ) { 
+   
     // options
     var opts = $.extend({}, $.fn.jclock.defaults, options);
          
@@ -91,7 +94,50 @@
  
       $.fn.jclock.startClock($this);
  
+      $this.data('clock', $this);
     });
+        
+   },
+   /**
+    * Dynamically change the seedTime
+    */   
+   setSeedTime : function( seedTime ) { 
+    return this.each(function(){
+        var $this = $(this).data('clock');
+        if ($this != null) {        
+            $this.seedTime = seedTime;
+            
+            // Reset variables used for record keeping
+            $this.increment = 0;
+            $this.lastCalled = new Date().getTime();            
+        }
+    });
+   },   
+   /**
+    * Stop the clock's timer, for example in 
+    * preparation to destroy the clock instance.
+    */
+   stopClock: function( ) {  
+    return this.each(function(){
+        var $this = $(this).data('clock');
+        if ($this != null) {      
+            clearTimeout($this.timerID);
+        }
+    });
+   }
+  };
+ 
+  $.fn.jclock = function( method ) {
+    
+    // Method calling logic
+    if ( methods[method] ) {
+      return methods[ method ].apply( this, Array.prototype.slice.call( arguments, 1 ));
+    } else if ( typeof method === 'object' || ! method ) {
+      return methods.init.apply( this, arguments );
+    } else {
+      $.error( 'Method ' +  method + ' does not exist on jQuery.jclock' );
+    }    
+  
   };
        
   $.fn.jclock.startClock = function(el) {
@@ -126,13 +172,15 @@
   }
 
   $.fn.jclock.currentTime = function(el) {
+    var now;
+    
     if(typeof(el.seedTime) == 'undefined') {
       // Seed time not being used, use current time
-      var now = new Date();
+      now = new Date();
     } else {
       // Otherwise, use seed time with increment
       el.increment += new Date().getTime() - el.lastCalled;
-      var now = new Date(el.seedTime + el.increment);
+      now = new Date(el.seedTime + el.increment);
       el.lastCalled = new Date().getTime();
     }
  
@@ -141,7 +189,7 @@
       var localOffset = now.getTimezoneOffset() * 60000;
       var utc = localTime + localOffset;
       var utcTime = utc + (3600000 * el.utcOffset);
-      var now = new Date(utcTime);
+      now = new Date(utcTime);
     }
 
     return now


### PR DESCRIPTION
In a recent project I had a need to dynamically update a clock, so I added the following methods:
- `setSeedTime` - This method allows the seedTime to be changed dynamically. For example:
  
  $('.jclock').jclock('setSeedTime', (new Date()).getTime());
- `stopClock` - This method clears the clock's internal timer, stopping the clock. This could also be used in preparation for cleaning up a clock:
  
  $('.jclock').jclock('stopClock');
- `startClock` - This method will restart a stopped clock:
  
  $('.jclock').jclock('startClock');

There are also two new example files to demonstrate how to use these new methods.
